### PR TITLE
Update PHP version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,14 +11,47 @@ env:
   fail-fast: true
 
 jobs:
+  checks:
+    name: Code Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
+
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: "highest"
+          composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
+
+      - name: Run PHP CS Fixer
+        run: vendor/bin/php-cs-fixer check --using-cache=no --config vendor/kununu/scripts/src/PHP/CodeStandards/Scripts/php_cs src/ tests/
+
+      - name: Run Rector
+        run: vendor/bin/rector process --ansi --dry-run --config rector-ci.php src/ tests/
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --ansi
+
   build:
+    needs: checks
     name: PHPUnit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php-version:
-          - 8.1
+          - 8.3
         dependencies:
+          - lowest
           - highest
 
     steps:
@@ -38,7 +71,7 @@ jobs:
           composer-options: "--prefer-stable"
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml
+        run: vendor/bin/phpunit --colors=always --testdox --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml
 
       - name: Upload coverage files
         uses: actions/upload-artifact@v4
@@ -49,6 +82,7 @@ jobs:
 
   sonarcloud:
     needs: build
+    name: SonarCloud Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +92,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-8.1-highest-coverage
+          name: build-8.3-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths
@@ -68,7 +102,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v3.0.0
+        uses: SonarSource/sonarqube-scan-action@v4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ composer require jms/serializer-bundle
 
 ## Concepts
 
+- [Cache Cleaner](docs/cache-cleaner.md)
 - [Projection Item](docs/projection-item.md)
-- [Repository](docs/repository.md)
 - [Provider](docs/provider.md)
+- [Repository](docs/repository.md)
 - [Serialization](docs/serialization.md)
 
 ## Integrations

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,17 @@
     }
   ],
   "require": {
-    "php": ">=8.1"
+    "php": ">=8.3"
   },
   "require-dev": {
     "ext-json": "*",
     "ext-igbinary": "*",
     "ext-zlib": "*",
-    "phpunit/phpunit": "^10.5",
-    "kununu/scripts": ">=4.0",
+    "kununu/scripts": ">=5.1",
+    "phpstan/phpstan": "^2.1",
+    "phpstan/phpstan-phpunit": "^2.0",
+    "phpunit/phpunit": "^11.5",
+    "rector/rector": "^2.0",
     "symfony/yaml": "^6.4",
     "symfony/cache": "^6.4",
     "jms/serializer": "^3.28",
@@ -54,11 +57,15 @@
   },
   "scripts": {
     "test": "phpunit --no-coverage --no-logging --no-progress",
-    "test-coverage": "XDEBUG_MODE=coverage phpunit"
+    "test-coverage": "XDEBUG_MODE=coverage phpunit",
+    "rector": "rector process --dry-run --config rector-ci.php src/ tests/",
+    "phpstan": "phpstan"
   },
   "scripts-descriptions": {
     "test": "Run all tests",
-    "test-coverage": "Run all tests with coverage report"
+    "test-coverage": "Run all tests with coverage report",
+    "rector": "Run Rector in dry-run mode with CI rules",
+    "phpstan": "Run PHPStan"
   },
   "config": {
     "allow-plugins": {

--- a/docs/cache-cleaner.md
+++ b/docs/cache-cleaner.md
@@ -97,7 +97,7 @@ use Psr\Log\LoggerInterface;
 
 final class MyCacheCleanerTest extends AbstractCacheCleanerTestCase
 {
-    protected const TAGS = ['my-tag1', 'my-tag2'];
+    protected const array TAGS = ['my-tag1', 'my-tag2'];
 
     protected function getCacheCleaner(
         ProjectionRepositoryInterface $projectionRepository,
@@ -179,3 +179,7 @@ $myClass = new MyClass($cacheCleaner);
 // When I call `myMethod` it will clear all the caches as defined on each cleaner injected into the chain $cacheCleaner
 $myClass->myMethod();
 ```
+
+---
+
+[Back to Index](../README.md)

--- a/docs/projection-item.md
+++ b/docs/projection-item.md
@@ -72,3 +72,7 @@ interface ProjectionItemIterableInterface extends ProjectionItemInterface
 A trait called `ProjectionItemIterableTrait` is provided with those methods already implemented and with the data stored as an array, so just use it your projection item classes, and you're good to go.
 
 Just bear in mind that the trait is only implementing the methods defined in `ProjectionItemIterableInterface` and not those of `ProjectionItemInterface` so it is still responsibility of your projection item class to implement them!
+
+---
+
+[Back to Index](../README.md)

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -275,6 +275,36 @@ public static function getCustomerDataDataProvider(): array
 }
 ```
 
+### SimpleCachedProviderTestTrait
+
+If you don't need the level of complexity provided by `AbstractCachedProviderTestCase` you can use the `SimpleCachedProviderTestTrait` trait instead.
+
+Just include the trait in your test class and in your test use the following method:
+
+```php
+private function configureCachedProvider(
+    MockObject&ProjectionRepositoryInterface $projectionRepository,
+    MockObject $originalProvider,
+    string $method,
+    bool $expectCacheMiss,
+    ProjectionItemInterface $searchItem,
+    ProjectionItemInterface $sourceItem,
+    mixed $originalResult,
+): void
+```
+
+- `$projectionRepository` - A mock instance of your projection repository
+- `$originalProvider`     - A mock instance of your original (non-cached) provider
+- `$method`               - The method on your provider you are configuring
+- `$expectCacheMiss`      - If you are expecting a cache miss or a cache hit
+- `$searchItem`           - The projection item instance used to search on the cache
+- `$sourceItem`           - The projection item instance that will be used to store data on the cache
+- `$originalResult`       - The original result returned from the non-cached provider that will be stored on the cache
+
+Example:
+
+See [SimpleCachedProviderTestTraitTest](../tests/Provider/SimpleCachedProviderTestTraitTest.php) for an example.
+
 ---
 
 [Back to Index](../README.md)

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -35,7 +35,7 @@ interface ProjectionRepositoryInterface
 
 This class implements a repository, which projects the items using [Symfony's Tag Aware Cache Pool component](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Contracts/Cache/TagAwareCacheInterface.php).
 
-This means that then when projecting an [item](docs/projection-item.md), if tags are available for it, the item will also include tags and those items can be invalidated in the cache with the `deleteByTags` method.  
+This means that then when projecting an [item](projection-item.md), if tags are available for it, the item will also include tags and those items can be invalidated in the cache with the `deleteByTags` method.  
 
 ### Psr6CacheProjectionRepository
 
@@ -46,3 +46,7 @@ Unlike the `SymfonyCacheProjectionRepository`, no support for tags is available 
 If your PSR-6 implementation supports tags then is up to you to create an implementation of `ProjectionRepositoryInterface` and make the required changes.
 
 You expand `AbstractProjectionRepository` and do the required changes to `deleteByTags` and `createCacheItem` methods. See `SymfonyCacheProjectionRepository` which does just that. 
+
+---
+
+[Back to Index](../README.md)

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -58,7 +58,7 @@ $repository->add($myItem);
 
 ### PhpCacheSerializer
 
-This implementation is a wrapper for PHP's [internal serializer](https://www.php.net/manual/en/function.serialize.php) and [internal serializer](https://www.php.net/manual/en/function.unserialize).
+This implementation is a wrapper for PHP's [internal serializer](https://www.php.net/manual/en/function.serialize.php) and [internal un-serializer](https://www.php.net/manual/en/function.unserialize).
 
 ```php
 use Kununu\Projections\Repository\Psr6CacheProjectionRepository;
@@ -119,3 +119,6 @@ services:
     arguments: [ '@.inner' ]
 ```
 
+---
+
+[Back to Index](../README.md)

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -120,9 +120,9 @@ use Kununu\Projections\ProjectionRepositoryInterface;
 use Kununu\Projections\Tag\Tag;
 use Kununu\Projections\Tag\Tags;
 
-final class MyProvider
+final readonly class MyProvider
 {
-    public function __construct(private readonly ProjectionRepositoryInterface $projectionRepository)
+    public function __construct(private ProjectionRepositoryInterface $projectionRepository)
     {
     }
 
@@ -155,3 +155,7 @@ final class MyProvider
 ```
 
 Now we can start reading, setting and deleting from the cache pool :)
+
+---
+
+[Back to Index](../README.md)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+  - vendor/phpstan/phpstan-phpunit/extension.neon
+  - vendor/phpstan/phpstan-phpunit/rules.neon
+parameters:
+	level: 5
+	paths:
+		- src
+		- tests
+	errorFormat: table

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://docs.phpunit.de/en/10.5/ -->
+<!-- https://docs.phpunit.de/en/11.5/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php"
-         colors="true" beStrictAboutChangesToGlobalState="true" cacheDirectory=".phpunit.cache" testdox="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" beStrictAboutChangesToGlobalState="true" testdoxSummary="true" testdox="true"
+         cacheDirectory=".phpunit.cache">
   <coverage>
     <report>
       <clover outputFile="tests/.results/tests-clover.xml"/>
@@ -10,7 +11,7 @@
     </report>
   </coverage>
   <testsuites>
-    <testsuite name="Projections Test Suite">
+    <testsuite name="Full">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
+
+return RectorConfig::configure()
+    ->withPhpSets(php83: true)
+    ->withAttributesSets(phpunit: true)
+    ->withSets([
+        PHPUnitSetList::PHPUNIT_110,
+    ])
+    ->withRules([
+        FinalizeTestCaseClassRector::class,
+        PreferPHPUnitSelfCallRector::class,
+    ])
+    ->withSkip([
+        __DIR__ . '/rector-ci.php',
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+    ])
+    ->withImportNames();

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectVersion=1.0
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=.
-sonar.exclusions=tests/**
+sonar.exclusions=rector-ci.php,tests/**
 sonar.tests=tests
 
 sonar.coverage.exclusion=tests/**

--- a/src/CacheCleaner/AbstractCacheCleanerByTags.php
+++ b/src/CacheCleaner/AbstractCacheCleanerByTags.php
@@ -13,7 +13,7 @@ abstract class AbstractCacheCleanerByTags implements CacheCleanerInterface
     public function __construct(
         private readonly ProjectionRepositoryInterface $projectionRepository,
         private readonly LoggerInterface $logger,
-        private readonly string $logLevel = LogLevel::INFO
+        private readonly string $logLevel = LogLevel::INFO,
     ) {
     }
 

--- a/src/CacheCleaner/CacheCleanerChain.php
+++ b/src/CacheCleaner/CacheCleanerChain.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Kununu\Projections\CacheCleaner;
 
-final class CacheCleanerChain implements CacheCleanerInterface
+final readonly class CacheCleanerChain implements CacheCleanerInterface
 {
-    /** @var CacheCleanerInterface[] */
-    private readonly array $cacheCleaners;
+    /** @var array<CacheCleanerInterface> */
+    private array $cacheCleaners;
 
     public function __construct(CacheCleanerInterface ...$cacheCleaners)
     {

--- a/src/ProjectionItemIterableTrait.php
+++ b/src/ProjectionItemIterableTrait.php
@@ -14,7 +14,9 @@ trait ProjectionItemIterableTrait
     public function storeData(iterable $data): ProjectionItemIterableInterface
     {
         if (!is_a($this, ProjectionItemIterableInterface::class)) {
-            throw new BadMethodCallException(sprintf('Class using this trait must be a %s', ProjectionItemIterableInterface::class));
+            throw new BadMethodCallException(
+                sprintf('Class using this trait must be a %s', ProjectionItemIterableInterface::class)
+            );
         }
 
         if (is_array($data)) {

--- a/src/Provider/AbstractCachedProvider.php
+++ b/src/Provider/AbstractCachedProvider.php
@@ -10,14 +10,14 @@ use Psr\Log\LogLevel;
 
 abstract class AbstractCachedProvider
 {
-    private const CACHE_KEY = 'cache_key';
-    private const CLASS_KEY = 'class';
-    private const DATA_KEY = 'data';
+    private const string CACHE_KEY = 'cache_key';
+    private const string CLASS_KEY = 'class';
+    private const string DATA_KEY = 'data';
 
     public function __construct(
         private readonly ProjectionRepositoryInterface $projectionRepository,
         private readonly LoggerInterface $logger,
-        private readonly string $logLevel = LogLevel::INFO
+        private readonly string $logLevel = LogLevel::INFO,
     ) {
     }
 
@@ -29,7 +29,7 @@ abstract class AbstractCachedProvider
     protected function getAndCacheData(
         ProjectionItemIterableInterface $item,
         callable $dataGetter,
-        callable ...$preProjections
+        callable ...$preProjections,
     ): ?iterable {
         $key = $item->getKey();
 

--- a/src/Repository/AbstractProjectionRepository.php
+++ b/src/Repository/AbstractProjectionRepository.php
@@ -15,7 +15,7 @@ abstract class AbstractProjectionRepository implements ProjectionRepositoryInter
 {
     public function __construct(
         protected readonly CacheItemPoolInterface $cachePool,
-        protected readonly CacheSerializerInterface $serializer
+        protected readonly CacheSerializerInterface $serializer,
     ) {
     }
 

--- a/src/Repository/SymfonyCacheProjectionRepository.php
+++ b/src/Repository/SymfonyCacheProjectionRepository.php
@@ -9,6 +9,7 @@ use Kununu\Projections\Serializer\CacheSerializerInterface;
 use Kununu\Projections\Tag\Tags;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\CacheItem;
 
 final class SymfonyCacheProjectionRepository extends AbstractProjectionRepository
 {
@@ -26,7 +27,7 @@ final class SymfonyCacheProjectionRepository extends AbstractProjectionRepositor
 
     protected function createCacheItem(ProjectionItemInterface $item): CacheItemInterface
     {
-        $cacheItem = parent::createCacheItem($item);
+        $cacheItem = $this->convertCacheItem(parent::createCacheItem($item));
         $cacheItem->tag($item->getTags()->raw());
 
         return $cacheItem;
@@ -37,5 +38,12 @@ final class SymfonyCacheProjectionRepository extends AbstractProjectionRepositor
         assert($this->cachePool instanceof TagAwareAdapterInterface);
 
         return $this->cachePool;
+    }
+
+    private function convertCacheItem(CacheItemInterface $cacheItem): CacheItem
+    {
+        assert($cacheItem instanceof CacheItem);
+
+        return $cacheItem;
     }
 }

--- a/src/Serializer/Provider/JMSCacheSerializer.php
+++ b/src/Serializer/Provider/JMSCacheSerializer.php
@@ -6,11 +6,11 @@ namespace Kununu\Projections\Serializer\Provider;
 use JMS\Serializer\SerializerInterface;
 use Kununu\Projections\Serializer\CacheSerializerInterface;
 
-final class JMSCacheSerializer implements CacheSerializerInterface
+final readonly class JMSCacheSerializer implements CacheSerializerInterface
 {
-    private const SERIALIZER_FORMAT = 'json';
+    private const string SERIALIZER_FORMAT = 'json';
 
-    public function __construct(private readonly SerializerInterface $serializer)
+    public function __construct(private SerializerInterface $serializer)
     {
     }
 

--- a/src/Serializer/Provider/SymfonyCacheSerializer.php
+++ b/src/Serializer/Provider/SymfonyCacheSerializer.php
@@ -6,11 +6,11 @@ namespace Kununu\Projections\Serializer\Provider;
 use Kununu\Projections\Serializer\CacheSerializerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
-final class SymfonyCacheSerializer implements CacheSerializerInterface
+final readonly class SymfonyCacheSerializer implements CacheSerializerInterface
 {
-    private const SERIALIZER_FORMAT = 'json';
+    private const string SERIALIZER_FORMAT = 'json';
 
-    public function __construct(private readonly SerializerInterface $serializer)
+    public function __construct(private SerializerInterface $serializer)
     {
     }
 

--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -5,9 +5,9 @@ namespace Kununu\Projections\Tag;
 
 use Stringable;
 
-final class Tag implements Stringable
+final readonly class Tag implements Stringable
 {
-    public function __construct(public readonly string $tag)
+    public function __construct(public string $tag)
     {
     }
 

--- a/src/Tag/Tags.php
+++ b/src/Tag/Tags.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Kununu\Projections\Tag;
 
-final class Tags
+final readonly class Tags
 {
-    private readonly array $tags;
+    /** @var array<Tag> */
+    private array $tags;
 
     public function __construct(Tag ...$tags)
     {

--- a/src/TestCase/CacheCleaner/AbstractCacheCleanerTestCase.php
+++ b/src/TestCase/CacheCleaner/AbstractCacheCleanerTestCase.php
@@ -16,22 +16,22 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 abstract class AbstractCacheCleanerTestCase extends TestCase
 {
-    protected const TAGS = [];
+    protected const array TAGS = [];
 
-    protected MockObject|TagAwareAdapterInterface $cachePool;
-    protected MockObject|LoggerInterface $logger;
+    protected MockObject&TagAwareAdapterInterface $cachePool;
+    protected MockObject&LoggerInterface $logger;
     protected CacheCleanerInterface $cacheCleaner;
 
     public function testCacheCleaner(): void
     {
         $this->cachePool
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('invalidateTags')
             ->with(static::TAGS)
             ->willReturn(true);
 
         $this->logger
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('log')
             ->with(
                 LogLevel::INFO,
@@ -45,13 +45,13 @@ abstract class AbstractCacheCleanerTestCase extends TestCase
     public function testCacheCleanerFail(): void
     {
         $this->cachePool
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('invalidateTags')
             ->with(static::TAGS)
             ->willReturn(false);
 
         $this->logger
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('log')
             ->with(
                 LogLevel::INFO,
@@ -67,7 +67,7 @@ abstract class AbstractCacheCleanerTestCase extends TestCase
 
     abstract protected function getCacheCleaner(
         ProjectionRepositoryInterface $projectionRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
     ): CacheCleanerInterface;
 
     protected function setUp(): void

--- a/src/TestCase/Provider/SimpleCachedProviderTestTrait.php
+++ b/src/TestCase/Provider/SimpleCachedProviderTestTrait.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Projections\TestCase\Provider;
+
+use Kununu\Projections\ProjectionItemInterface;
+use Kununu\Projections\ProjectionRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+trait SimpleCachedProviderTestTrait
+{
+    private function configureCachedProvider(
+        MockObject&ProjectionRepositoryInterface $projectionRepository,
+        MockObject $originalProvider,
+        string $method,
+        bool $expectCacheMiss,
+        ProjectionItemInterface $searchItem,
+        ProjectionItemInterface $sourceItem,
+        mixed $originalResult,
+    ): void {
+        $projectionRepository
+            ->expects($this->once())
+            ->method('get')
+            ->with($searchItem)
+            ->willReturn($expectCacheMiss ? null : $sourceItem);
+
+        if ($expectCacheMiss) {
+            $originalProvider
+                ->expects($this->once())
+                ->method($method)
+                ->willReturn($originalResult);
+        } else {
+            $originalProvider
+                ->expects($this->never())
+                ->method($method);
+        }
+
+        if ($expectCacheMiss && $originalResult) {
+            $projectionRepository
+                ->expects($this->once())
+                ->method('add')
+                ->with($sourceItem);
+        } else {
+            $projectionRepository
+                ->expects($this->never())
+                ->method('add');
+        }
+    }
+}

--- a/tests/CacheCleaner/AbstractCacheCleanerByTagsTest.php
+++ b/tests/CacheCleaner/AbstractCacheCleanerByTagsTest.php
@@ -13,11 +13,11 @@ use Psr\Log\LoggerInterface;
 
 final class AbstractCacheCleanerByTagsTest extends AbstractCacheCleanerTestCase
 {
-    protected const TAGS = ['my-tag1', 'my-tag2'];
+    protected const array TAGS = ['my-tag1', 'my-tag2'];
 
     protected function getCacheCleaner(
         ProjectionRepositoryInterface $projectionRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
     ): CacheCleanerInterface {
         return new class($projectionRepository, $logger) extends AbstractCacheCleanerByTags {
             use ProjectionTagGenerator;

--- a/tests/CacheCleaner/CacheCleanerChainTest.php
+++ b/tests/CacheCleaner/CacheCleanerChainTest.php
@@ -25,7 +25,7 @@ final class CacheCleanerChainTest extends TestCase
         $cleaner = $this->createMock(CacheCleanerInterface::class);
 
         $cleaner
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clear');
 
         return $cleaner;

--- a/tests/ProjectionItemIterableTraitTest.php
+++ b/tests/ProjectionItemIterableTraitTest.php
@@ -14,7 +14,7 @@ final class ProjectionItemIterableTraitTest extends TestCase
 {
     public function testTrait(): void
     {
-        $validClass = new class() implements ProjectionItemIterableInterface {
+        $validClass = new class implements ProjectionItemIterableInterface {
             use ProjectionItemIterableTrait;
 
             public function getKey(): string
@@ -40,7 +40,7 @@ final class ProjectionItemIterableTraitTest extends TestCase
 
         self::assertEquals(['a', 'b', 5], $validClass->data());
 
-        $invalidClass = new class() {
+        $invalidClass = new class {
             use ProjectionItemIterableTrait;
         };
 

--- a/tests/Provider/CachedProviderTest.php
+++ b/tests/Provider/CachedProviderTest.php
@@ -11,7 +11,7 @@ use Kununu\Projections\Tests\Stubs\Provider\ProviderStubInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LogLevel;
 
-final class AbstractCachedProviderTest extends AbstractCachedProviderTestCase
+final class CachedProviderTest extends AbstractCachedProviderTestCase
 {
     protected const array METHODS = [
         self::METHOD_GET_DATA,

--- a/tests/Provider/SimpleCachedProviderTestTraitTest.php
+++ b/tests/Provider/SimpleCachedProviderTestTraitTest.php
@@ -56,7 +56,7 @@ final class SimpleCachedProviderTestTraitTest extends TestCase
                 'expected'        => self::RESULT,
                 'originalResult'  => null,
             ],
-            'cache_miss_return_schema' => [
+            'cache_miss_return_result' => [
                 'expectCacheMiss' => true,
                 'expected'        => self::RESULT,
                 'originalResult'  => self::RESULT,

--- a/tests/Provider/SimpleCachedProviderTestTraitTest.php
+++ b/tests/Provider/SimpleCachedProviderTestTraitTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Projections\Tests\Provider;
+
+use Kununu\Projections\ProjectionRepositoryInterface;
+use Kununu\Projections\TestCase\Provider\SimpleCachedProviderTestTrait;
+use Kununu\Projections\Tests\Stubs\ProjectionItem\ProjectionItemIterableStub;
+use Kununu\Projections\Tests\Stubs\Provider\CachedProviderStub;
+use Kununu\Projections\Tests\Stubs\Provider\ProviderStubInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class SimpleCachedProviderTestTraitTest extends TestCase
+{
+    use SimpleCachedProviderTestTrait;
+
+    private const string METHOD = 'getData';
+    private const string ID = '1';
+    private const array RESULT = [
+        'id'   => self::ID,
+        'name' => 'The Name of 1',
+        'age'  => 21,
+    ];
+
+    private MockObject&ProviderStubInterface $originalProvider;
+    private MockObject&ProjectionRepositoryInterface $projectionRepository;
+    private ProviderStubInterface $provider;
+
+    #[DataProvider('getDataDataProvider')]
+    public function testGetData(
+        bool $expectCacheMiss,
+        ?array $expected,
+        ?array $originalResult,
+    ): void {
+        $this->configureCachedProvider(
+            $this->projectionRepository,
+            $this->originalProvider,
+            self::METHOD,
+            $expectCacheMiss,
+            new ProjectionItemIterableStub(self::ID),
+            (new ProjectionItemIterableStub(self::ID))->storeData(self::RESULT),
+            $originalResult
+        );
+
+        self::assertEquals($expected, $this->provider->getData(self::ID));
+    }
+
+    public static function getDataDataProvider(): array
+    {
+        return [
+            'cache_hit'                => [
+                'expectCacheMiss' => false,
+                'expected'        => self::RESULT,
+                'originalResult'  => null,
+            ],
+            'cache_miss_return_schema' => [
+                'expectCacheMiss' => true,
+                'expected'        => self::RESULT,
+                'originalResult'  => self::RESULT,
+            ],
+            'cache_miss_return_null'   => [
+                'expectCacheMiss' => true,
+                'expected'        => null,
+                'originalResult'  => null,
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->originalProvider = $this->createMock(ProviderStubInterface::class);
+        $this->projectionRepository = $this->createMock(ProjectionRepositoryInterface::class);
+        $this->provider = new CachedProviderStub(
+            $this->originalProvider,
+            $this->projectionRepository,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+}

--- a/tests/Repository/Psr6CacheProjectionRepositoryTest.php
+++ b/tests/Repository/Psr6CacheProjectionRepositoryTest.php
@@ -18,10 +18,10 @@ final class Psr6CacheProjectionRepositoryTest extends AbstractProjectionReposito
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('PSR-6 does not support tags!');
 
-        $this->getProjectionRepository()->deleteByTags(new Tags(new Tag('tag_1'), new Tag('tag_2')));
+        $this->projectionRepository->deleteByTags(new Tags(new Tag('tag_1'), new Tag('tag_2')));
     }
 
-    protected function getCachePool(): MockObject|CacheItemPoolInterface
+    protected function getCachePool(): MockObject&CacheItemPoolInterface
     {
         if (null === $this->cachePool) {
             $this->cachePool = $this->createMock(CacheItemPoolInterface::class);

--- a/tests/Serializer/Provider/AbstractCacheSerializerTestCase.php
+++ b/tests/Serializer/Provider/AbstractCacheSerializerTestCase.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractCacheSerializerTestCase extends TestCase
 {
-    protected const RESULT_FILE = '';
+    protected const string RESULT_FILE = '';
 
     private CacheSerializerInterface $serializer;
     private ProjectionItemIterableStub $item;

--- a/tests/Serializer/Provider/IgBinaryCacheSerializerTest.php
+++ b/tests/Serializer/Provider/IgBinaryCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\IgBinaryCacheSerializer;
 
 final class IgBinaryCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'igbinary.result';
+    protected const string RESULT_FILE = 'igbinary.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/IgBinaryDeflatedCacheSerializerTest.php
+++ b/tests/Serializer/Provider/IgBinaryDeflatedCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\IgBinaryDeflatedCacheSerializer;
 
 final class IgBinaryDeflatedCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'igbinary-deflate.result';
+    protected const string RESULT_FILE = 'igbinary-deflate.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/JMSCacheSerializerTest.php
+++ b/tests/Serializer/Provider/JMSCacheSerializerTest.php
@@ -9,7 +9,7 @@ use Kununu\Projections\Serializer\Provider\JMSCacheSerializer;
 
 final class JMSCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'jms.result';
+    protected const string RESULT_FILE = 'jms.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/JMSDeflatedCacheSerializerTest.php
+++ b/tests/Serializer/Provider/JMSDeflatedCacheSerializerTest.php
@@ -9,7 +9,7 @@ use Kununu\Projections\Serializer\Provider\JMSDeflatedCacheSerializer;
 
 final class JMSDeflatedCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'jms-deflate.result';
+    protected const string RESULT_FILE = 'jms-deflate.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/PhpCacheSerializerTest.php
+++ b/tests/Serializer/Provider/PhpCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\PhpCacheSerializer;
 
 final class PhpCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'php.result';
+    protected const string RESULT_FILE = 'php.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/PhpDeflatedCacheSerializerTest.php
+++ b/tests/Serializer/Provider/PhpDeflatedCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\PhpDeflatedCacheSerializer;
 
 final class PhpDeflatedCacheSerializerTest extends AbstractCacheSerializerTestCase
 {
-    protected const RESULT_FILE = 'php-deflate.result';
+    protected const string RESULT_FILE = 'php-deflate.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/SymfonyCacheSerializerTest.php
+++ b/tests/Serializer/Provider/SymfonyCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\SymfonyCacheSerializer;
 
 final class SymfonyCacheSerializerTest extends AbstractSymfonySerializerTestCase
 {
-    protected const RESULT_FILE = 'symfony.result';
+    protected const string RESULT_FILE = 'symfony.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Serializer/Provider/SymfonyDeflatedCacheSerializerTest.php
+++ b/tests/Serializer/Provider/SymfonyDeflatedCacheSerializerTest.php
@@ -8,7 +8,7 @@ use Kununu\Projections\Serializer\Provider\SymfonyDeflatedCacheSerializer;
 
 final class SymfonyDeflatedCacheSerializerTest extends AbstractSymfonySerializerTestCase
 {
-    protected const RESULT_FILE = 'symfony-deflate.result';
+    protected const string RESULT_FILE = 'symfony-deflate.result';
 
     protected function getSerializer(): CacheSerializerInterface
     {

--- a/tests/Stubs/ProjectionItem/ProjectionItemIterableStub.php
+++ b/tests/Stubs/ProjectionItem/ProjectionItemIterableStub.php
@@ -13,7 +13,7 @@ final class ProjectionItemIterableStub implements ProjectionItemIterableInterfac
     use ProjectionItemIterableTrait;
     use ProjectionTagGenerator;
 
-    private const PROJECTION_KEY = 'test_iterable_%s';
+    private const string PROJECTION_KEY = 'test_iterable_%s';
 
     public function __construct(public readonly string $id, public readonly ?string $stuff = null)
     {

--- a/tests/Stubs/ProjectionItem/ProjectionItemStub.php
+++ b/tests/Stubs/ProjectionItem/ProjectionItemStub.php
@@ -7,11 +7,11 @@ use Kununu\Projections\ProjectionItemInterface;
 use Kununu\Projections\Tag\Tag;
 use Kununu\Projections\Tag\Tags;
 
-final class ProjectionItemStub implements ProjectionItemInterface
+final readonly class ProjectionItemStub implements ProjectionItemInterface
 {
-    private const PROJECTION_KEY = 'test_%s';
+    private const string PROJECTION_KEY = 'test_%s';
 
-    public function __construct(private readonly string $id)
+    public function __construct(private string $id)
     {
     }
 

--- a/tests/Stubs/Provider/CachedProviderStub.php
+++ b/tests/Stubs/Provider/CachedProviderStub.php
@@ -14,7 +14,7 @@ final class CachedProviderStub extends AbstractCachedProvider implements Provide
     public function __construct(
         private readonly ProviderStubInterface $provider,
         ProjectionRepositoryInterface $projectionRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
     ) {
         parent::__construct($projectionRepository, $logger);
     }

--- a/tests/Tag/ProjectionTagGeneratorTest.php
+++ b/tests/Tag/ProjectionTagGeneratorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Kununu\Projections\Tests\Tag;
 
 use Kununu\Projections\Tag\ProjectionTagGenerator;
-use Kununu\Projections\Tag\Tags;
 use PHPUnit\Framework\TestCase;
 
 final class ProjectionTagGeneratorTest extends TestCase
@@ -13,9 +12,8 @@ final class ProjectionTagGeneratorTest extends TestCase
 
     public function testCreateTagsFromArray(): void
     {
-        $tags = $this::createTagsFromArray('tag_1', 'tag_2');
+        $tags = $this::createTagsFromArray('tag_1', 'tag_2', 'tag_1');
 
-        self::assertInstanceOf(Tags::class, $tags);
         self::assertEquals(['tag_1', 'tag_2'], $tags->raw());
     }
 }

--- a/tests/Tag/TagTest.php
+++ b/tests/Tag/TagTest.php
@@ -12,7 +12,6 @@ final class TagTest extends TestCase
     {
         $tag = new Tag('tag');
 
-        self::assertInstanceOf(Tag::class, $tag);
         self::assertEquals('tag', $tag->tag);
     }
 


### PR DESCRIPTION
# Description

The objective of this PR is to bump minimum PHP version to 8.3 and fix errors on `AbstractCachedProviderTestCase` with PHPUnit 11.x.

## Details

## Breaking Changes
- Only support PHP 8.3
    - Make all constants typed
    - Make classes read-only when possible
    - Update CI pipeline to also use PHP 8.3
- On `AbstractCachedProviderTestCase`
    - `createExternalProvider` is now non-static
      - Use a callable in the data provider instead
    - Fixing errors with PHPUnit 11.x

## New

- Add `SimpleCachedProviderTestTrait`

## Other Changes
- Bump PHPUnit to 11.5
- Add Rector and PHPStan
    - Also add checks with those tools to CI
- Update documentation
