### PR TITLE
Update CI workflow to use main branch instead of master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -26,12 +26,22 @@ jobs:
         with:
           php-version: 8.3
           coverage: none
+          tools: composer-dependency-analyser, composer-normalize, composer-require-checker
 
       - name: Install Composer Dependencies
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: "highest"
           composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
+
+      - name: Run Composer Dependency Analyser
+        run: composer-dependency-analyser
+
+      - name: Run Composer Require Checker
+        run: composer-require-checker
+
+      - name: Run Composer Normalize
+        run: composer-normalize --dry-run --indent-size 2 --indent-style space --no-check-lock --no-update-lock
 
       - name: Run PHP CS Fixer
         run: vendor/bin/php-cs-fixer check --using-cache=no --config vendor/kununu/scripts/src/PHP/CodeStandards/Scripts/php_cs src/ tests/
@@ -50,6 +60,7 @@ jobs:
       matrix:
         php-version:
           - 8.3
+          - 8.4
         dependencies:
           - lowest
           - highest
@@ -57,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -68,10 +81,13 @@ jobs:
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.dependencies }}
-          composer-options: "--prefer-stable"
+          composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit --colors=always --testdox --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml
+        run: |
+          vendor/bin/phpunit --colors=always --testdox \
+            --log-junit tests/.results/tests-junit.xml \
+            --coverage-clover tests/.results/tests-clover.xml
 
       - name: Upload coverage files
         uses: actions/upload-artifact@v4
@@ -87,7 +103,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
@@ -102,7 +117,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.2
+        uses: SonarSource/sonarqube-scan-action@v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+return (new Configuration())
+    ->disableReportingUnmatchedIgnores()
+    ->ignoreErrors([ErrorType::DEV_DEPENDENCY_IN_PROD])
+    ->ignoreErrorsOnPackages(
+        [
+            'psr/log',
+            'psr/cache',
+        ],
+        [ErrorType::SHADOW_DEPENDENCY]
+    )
+    ->setFileExtensions(['php']);

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,20 @@
+{
+  "symbol-whitelist": [
+    "gzdeflate",
+    "gzinflate",
+    "igbinary_serialize",
+    "igbinary_unserialize",
+    "JMS\\Serializer\\Annotation\\Type",
+    "JMS\\Serializer\\SerializerInterface",
+    "PHPUnit\\Framework\\Attributes\\DataProvider",
+    "PHPUnit\\Framework\\MockObject\\MockObject",
+    "PHPUnit\\Framework\\TestCase",
+    "Psr\\Cache\\CacheItemInterface",
+    "Psr\\Cache\\CacheItemPoolInterface",
+    "Psr\\Log\\LoggerInterface",
+    "Psr\\Log\\LogLevel",
+    "Symfony\\Component\\Cache\\Adapter\\TagAwareAdapterInterface",
+    "Symfony\\Component\\Cache\\CacheItem",
+    "Symfony\\Component\\Serializer\\SerializerInterface"
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,8 @@
 {
   "name": "kununu/projections",
   "description": "Handle projections of items to cache",
-  "type": "library",
   "license": "MIT",
-  "minimum-stability": "stable",
+  "type": "library",
   "keywords": [
     "cache",
     "projections",
@@ -23,19 +22,20 @@
     "php": ">=8.3"
   },
   "require-dev": {
-    "ext-json": "*",
     "ext-igbinary": "*",
+    "ext-json": "*",
     "ext-zlib": "*",
-    "kununu/scripts": ">=5.1",
+    "jms/serializer": "^3.28",
+    "kununu/scripts": ">=6.1",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
-    "phpunit/phpunit": "^11.5",
+    "phpunit/phpunit": "^12.3",
     "rector/rector": "^2.0",
-    "symfony/yaml": "^6.4",
+    "shipmonk/composer-dependency-analyser": "^1.8",
     "symfony/cache": "^6.4",
-    "jms/serializer": "^3.28",
+    "symfony/property-access": "^6.4",
     "symfony/serializer": "^6.4",
-    "symfony/property-access": "^6.4"
+    "symfony/yaml": "^6.4"
   },
   "suggest": {
     "ext-igbinary": "To use IgBinary cache serializers",
@@ -45,6 +45,7 @@
     "symfony/property-access": "To use Symfony Serializer cache serializers",
     "symfony/serializer": "To use Symfony Serializer cache serializers"
   },
+  "minimum-stability": "stable",
   "autoload": {
     "psr-4": {
       "Kununu\\Projections\\": "src/"
@@ -55,21 +56,23 @@
       "Kununu\\Projections\\Tests\\": "tests/"
     }
   },
-  "scripts": {
-    "test": "phpunit --no-coverage --no-logging --no-progress",
-    "test-coverage": "XDEBUG_MODE=coverage phpunit",
-    "rector": "rector process --dry-run --config rector-ci.php src/ tests/",
-    "phpstan": "phpstan"
-  },
-  "scripts-descriptions": {
-    "test": "Run all tests",
-    "test-coverage": "Run all tests with coverage report",
-    "rector": "Run Rector in dry-run mode with CI rules",
-    "phpstan": "Run PHPStan"
-  },
   "config": {
     "allow-plugins": {
       "kununu/scripts": true
     }
+  },
+  "scripts": {
+    "cs": "composer kununu:cs-fixer-code src/ tests/",
+    "phpstan": "phpstan",
+    "rector": "rector process --dry-run --config rector-ci.php src/ tests/",
+    "test": "phpunit --no-coverage --no-logging --no-progress",
+    "test-coverage": "XDEBUG_MODE=coverage phpunit"
+  },
+  "scripts-descriptions": {
+    "cs": "Run PHP CS Fixer with kununu code standards",
+    "phpstan": "Run PHPStan",
+    "rector": "Run Rector in dry-run mode with CI rules",
+    "test": "Run all tests",
+    "test-coverage": "Run all tests with coverage report"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://docs.phpunit.de/en/11.5/ -->
+<!-- https://docs.phpunit.de/en/12.3/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php"
-         colors="true" beStrictAboutChangesToGlobalState="true" testdoxSummary="true" testdox="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         beStrictAboutChangesToGlobalState="true"
+         testdoxSummary="true"
+         testdox="true"
          cacheDirectory=".phpunit.cache">
   <coverage>
     <report>
@@ -22,5 +26,9 @@
     <include>
       <directory>src</directory>
     </include>
+    <exclude>
+      <file>composer-dependency-analyser.php</file>
+      <file>rector-ci.php</file>
+    </exclude>
   </source>
 </phpunit>

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
-use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 
 return RectorConfig::configure()
     ->withPhpSets(php83: true)
     ->withAttributesSets(phpunit: true)
-    ->withSets([
-        PHPUnitSetList::PHPUNIT_110,
-    ])
+    ->withComposerBased(phpunit: true)
     ->withRules([
         FinalizeTestCaseClassRector::class,
         PreferPHPUnitSelfCallRector::class,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectVersion=1.0
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=.
-sonar.exclusions=rector-ci.php,tests/**
+sonar.exclusions=composer-dependency-analyser.php,rector-ci.php,tests/**
 sonar.tests=tests
 
 sonar.coverage.exclusion=tests/**

--- a/src/ProjectionItemIterableTrait.php
+++ b/src/ProjectionItemIterableTrait.php
@@ -13,6 +13,7 @@ trait ProjectionItemIterableTrait
 
     public function storeData(iterable $data): ProjectionItemIterableInterface
     {
+        // @phpstan-ignore function.alreadyNarrowedType, function.impossibleType
         if (!is_a($this, ProjectionItemIterableInterface::class)) {
             throw new BadMethodCallException(
                 sprintf('Class using this trait must be a %s', ProjectionItemIterableInterface::class)

--- a/tests/Provider/CachedProviderTest.php
+++ b/tests/Provider/CachedProviderTest.php
@@ -143,12 +143,14 @@ final class CachedProviderTest extends AbstractCachedProviderTestCase
 
     public function testGetAndCacheDataDataProvider(): void
     {
-        $keys = array_map(
+        $expected = array_map(
             static fn(string $key): string => sprintf('getData_%s', $key),
             array_keys(self::getDataDataProvider())
         );
 
-        self::assertEquals(array_combine($keys, self::getDataDataProvider()), self::getAndCacheDataDataProvider());
+        $keys = array_keys(self::getAndCacheDataDataProvider());
+
+        self::assertEquals($expected, $keys);
     }
 
     protected function getProvider(mixed $originalProvider): CachedProviderStub


### PR DESCRIPTION
# Description

The objective of this PR is to update the continuous integration workflow to use `main` branch instead of `master`

## Details
- Change branch `master` to `main` on CI workflow
- Run Composer Dependency Analyser on CI workflow
- Run Composer Require Checker on CI workflow
- Run Composer Normalize on CI workflow
- Add PHP 8.4 to PHP versions matrix on CI workflow
- Normalize `composer.json` file
- Bump PHPUnit to ^12.3
- Bump to `SonarSource/sonarqube-scan-action@v5.3.0` on CI workflow
- Update Rector rules
- Exclude code tools config files from coverage
