### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/auto_assign_owner.yml
+++ b/.github/workflows/auto_assign_owner.yml
@@ -4,10 +4,7 @@ on:
     types: [ opened ]
 jobs:
   auto-assign-owner:
-    if: startsWith(github.event.ref, 'dependabot/') == false
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign owner
-        uses: danielswensson/auto-assign-owner-action@v1.0.6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: toshimaru/auto-author-assign@v3.0.2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
           tools: composer-dependency-analyser, composer-normalize, composer-require-checker, cs2pr
 
       - name: Install Composer Dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           dependency-versions: "highest"
           composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -85,19 +85,22 @@ jobs:
           coverage: pcov
 
       - name: Install Composer Dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
 
-      - name: Run tests with coverage
+      - name: Run PHPUnit
         run: |
-          vendor/bin/phpunit --colors=always --testdox \
-            --log-junit tests/.results/tests-junit.xml \
-            --coverage-clover tests/.results/tests-clover.xml
+          vendor/bin/phpunit \
+            --colors=always \
+            --testdox \
+            --testdox-summary \
+            --coverage-clover tests/.results/tests-clover.xml \
+            --log-junit tests/.results/tests-junit.xml
 
       - name: Upload coverage files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.job }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-coverage
           include-hidden-files: true
@@ -108,11 +111,11 @@ jobs:
     name: Code Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: tests-8.4-highest-coverage
           path: tests/.results/
@@ -124,7 +127,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     "kununu/code-tools": "^4.0",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
-    "phpunit/phpunit": "^12.5",
-    "rector/rector": "^2.0",
+    "phpunit/phpunit": "^13.1",
+    "rector/rector": "^2.4",
     "shipmonk/composer-dependency-analyser": "^1.8",
     "symfony/cache": "^6.4 || ^7.4",
     "symfony/property-access": "^6.4 || ^7.4",
@@ -77,15 +77,17 @@
     "rector": "rector process --dry-run --config rector-ci.php src/ tests/",
     "rector-fix": "rector process --config rector-ci.php src/ tests/",
     "sniffer": "phpcs",
-    "test": "phpunit --no-coverage --no-logging --no-progress",
-    "test-coverage": "XDEBUG_MODE=coverage phpunit"
+    "sniffer-fix": "phpcbf",
+    "test": "phpunit --testsuite Full --testdox --testdox-summary --no-coverage --no-logging",
+    "test-coverage": "XDEBUG_MODE=coverage phpunit --testsuite Full --testdox --testdox-summary --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml --coverage-html tests/.results/html/"
   },
   "scripts-descriptions": {
     "cs": "Run PHP CS Fixer with kununu code standards",
     "phpstan": "Run PHPStan",
     "rector": "Run Rector in dry-run mode with CI rules",
-    "rector-fix": "rector process --config rector-ci.php src/ tests/",
+    "rector-fix": "Run Rector in fix mode with CI rules",
     "sniffer": "Run PHP_CodeSniffer",
+    "sniffer-fix": "Run PHP_CodeSniffer in fix mode",
     "test": "Run all tests",
     "test-coverage": "Run all tests with coverage report"
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://docs.phpunit.de/en/12.5/ -->
+<!-- https://docs.phpunit.de/en/13.1/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
-         beStrictAboutChangesToGlobalState="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         cacheDirectory=".phpunit.cache"
          colors="true"
+         beStrictAboutChangesToGlobalState="true"
          displayDetailsOnAllIssues="true"
-         testdoxSummary="true"
-         testdox="true">
-    <coverage>
-        <report>
-            <clover outputFile="tests/.results/tests-clover.xml"/>
-            <html outputDirectory="tests/.results/html/"/>
-        </report>
-    </coverage>
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Full">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <logging>
-        <junit outputFile="tests/.results/tests-junit.xml"/>
-    </logging>
     <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
             <directory>src</directory>

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
-use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
-use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 
 return RectorConfig::configure()
@@ -19,11 +17,5 @@ return RectorConfig::configure()
     ->withSkip([
         __DIR__ . '/rector-ci.php',
         AddOverrideAttributeToOverriddenMethodsRector::class,
-        CreateStubOverCreateMockArgRector::class    => [
-            __DIR__ . '/src/TestCase/CacheCleaner/AbstractCacheCleanerTestCase.php',
-        ],
-        PropertyCreateMockToCreateStubRector::class => [
-            __DIR__ . '/tests/Provider/SimpleCachedProviderTestTraitTest.php',
-        ],
     ])
     ->withImportNames();


### PR DESCRIPTION
# Description

The objective of this PR is to bump GHA used in the CI workflow

## Details
- Bump GitHub Actions versions
- Bump PHPUnit to ^13.1
- Replace `danielswensson/auto-assign-owner-action` with `toshimaru/auto-author-assign` in auto assign owner workflow file
