### PR TITLE
docs: add kun-init 4-file documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+Steering notes for AI agents working in this repository. For installation and
+usage see [README.md](README.md); for dev setup, testing, and the PR process see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What this is
+
+`kununu/projections` is a PHP library that handles projections of items to a
+cache. A projection is short-lived, faster-to-read storage (e.g. cache) placed
+in front of a slower source of truth. The library ships the interfaces for
+projection logic plus an implementation over Symfony's Tag Aware Cache Pool.
+
+Consumed as a Composer package (`kununu/projections`); it is not a deployable
+service.
+
+## Domain concepts
+
+- **Projection item** — the unit that is projected, identified by a key and
+  carrying tags (`ProjectionItemInterface`).
+- **Repository** — projects, reads, and deletes items
+  (`ProjectionRepositoryInterface`); `add`/`addDeferred`/`flush`, `get`,
+  `delete`, `deleteByTags`.
+- **Provider** — orchestrates fetch-or-cache around a repository
+  (`AbstractCachedProvider`).
+- **Serializer** — encodes items for cache storage (`CacheSerializerInterface`),
+  with PHP, IgBinary, JMS, and Symfony variants plus deflate decorators.
+- **Cache cleaner** — invalidates projections by tags (`CacheCleanerInterface`).
+- **Tag / Tags** — value objects for tagging projections.
+
+Deep docs live in `docs/` and are indexed from the README: cache-cleaner,
+projection-item, provider, repository, serialization, symfony.
+
+## Code layout
+
+- `src/` — library code, PSR-4 `Kununu\Projections\`.
+  - `CacheCleaner/`, `Provider/`, `Repository/`, `Serializer/`, `Tag/`,
+    `Exception/`.
+  - `TestCase/` — reusable abstract test cases and traits shipped for consumers
+    to test their own providers, cache cleaners, and repositories.
+- `tests/` — PHPUnit tests, PSR-4 `Kununu\Projections\Tests\`. Reusable test
+  fixtures live in `tests/Stubs/`.
+- `docs/` — concept documentation.
+
+## Quality gates
+
+PHP version is pinned in `composer.json` (`require.php`). Run via Composer
+scripts (see `scripts` in `composer.json`):
+
+- `composer test` — PHPUnit.
+- `composer phpstan` — static analysis.
+- `composer cs` — PHP CS Fixer (kununu standards).
+- `composer sniffer` — PHP_CodeSniffer (`sniffer-fix` to autofix).
+- `composer rector` — Rector dry-run (`rector-fix` to apply).
+
+CI (`.github/workflows/continuous-integration.yml`) additionally runs
+composer-dependency-analyser, composer-require-checker, composer-normalize, and
+a SonarCloud scan.
+
+## Hard constraints
+
+- Every code change must ship with tests; PRs without tests are not accepted.
+- Follow kununu coding standards (PSR-2 extension via `kununu/code-tools`);
+  keep `declare(strict_types=1);` in every PHP file.
+- Public API changes are subject to SemVer — avoid breaking changes where
+  possible and document them.
+- Keep runtime dependencies optional: extra packages (Symfony cache, JMS, ext-*)
+  are declared under `require-dev`/`suggest`, not `require`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,54 @@
 # Contributing
 
-Contributions are more than **welcome**.
+Contributions are more than **welcome**. We accept contributions via Pull
+Requests on [GitHub](https://github.com/kununu/projections).
 
-We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/projections).
+## Development setup
 
-## Pull Requests
+Install the dependencies with Composer:
 
-- **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
-  
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
+```bash
+composer install
+```
 
-- **Document any change in behaviour** - Make sure the `CHANGELOG.md`, `README.md` and any other relevant documentation are kept up-to-date.
+The [kununu Coding Standards](https://github.com/kununu/kununu-scripts) are an
+extension of [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
+The `kununu/code-tools` package is installed as a dev dependency and exposes the
+commands used to meet those standards.
 
-- **Consider our release cycle** - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
+## Quality gates
 
-- **Create feature branches** - Master is the stable branch, create a new branch for each feature.
+Run the checks locally before opening a pull request (see the `scripts` section
+of `composer.json` for the full list):
 
-- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+```bash
+composer test       # PHPUnit
+composer phpstan    # static analysis
+composer cs         # PHP CS Fixer (kununu standards)
+composer sniffer    # PHP_CodeSniffer (composer sniffer-fix to autofix)
+composer rector     # Rector dry-run (composer rector-fix to apply)
+```
 
-- **Be respectful** - Be excellent to other contributors. See our [Code of Conduct](CODE_OF_CONDUCT.md).
+Use `composer test-coverage` to run the suite with a coverage report.
+
+The same checks run in CI
+(`.github/workflows/continuous-integration.yml`), which also runs
+composer-dependency-analyser, composer-require-checker, composer-normalize, and
+a SonarCloud scan.
+
+## Pull requests
+
+- **Add tests** — to keep a high quality code base, a patch cannot be accepted
+  if it does not have tests.
+- **Document any change in behaviour** — keep `CHANGELOG.md`, `README.md`, and
+  any other relevant documentation up to date.
+- **Consider the release cycle** — this library uses semantic versioning
+  ([SemVer v2.0.0](https://semver.org/)). Changes to the public API must be made
+  with great consideration and avoided where possible.
+- **Create feature branches** — `main` is the stable branch; create a new branch
+  for each feature.
+- **One pull request per feature** — send multiple pull requests if you want to
+  do more than one thing.
+- **Be respectful** — see our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 **Happy coding**!

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ composer require jms/serializer-bundle
 ## Integrations
 - [Symfony Integrations](docs/symfony.md)
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, quality gates, and
+the pull request process.
+
 ------------------------------
 
 ![Continuous Integration](https://github.com/kununu/projections/actions/workflows/continuous-integration.yml/badge.svg)


### PR DESCRIPTION
# Description

The objective of this PR is to add the kun-init 4-file documentation structure with strict, non-overlapping ownership so both humans and AI agents have a single source of truth for each concern.

## Issues

- KUNAI-8

## Details

- **README.md** (humans + agents): what the library is, installation, usage. Added a `## Contributing` section linking `CONTRIBUTING.md`.
- **AGENTS.md** (agents only): short steering doc — domain concepts, code layout, quality gates (real composer scripts), and hard constraints. Points to `docs/` and `CONTRIBUTING.md`; no dev-setup duplication.
- **CONTRIBUTING.md** (humans + agents): reconciled the existing file to own all dev workflow — setup, quality gates, testing, and the PR/merge process.
- **CLAUDE.md**: `@AGENTS.md` include so Claude picks up the same steering doc.

Docs-only change. No source, config, or dependency changes.
